### PR TITLE
override jekyll's minima theme with main.scss to justify body text

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,10 @@
+---
+---
+
+@import "minima";
+
+body {
+  hyphens: auto;
+  text-align: justify;
+  text-justify: inter-word;
+}


### PR DESCRIPTION
override jekyll's minima theme with `main.scss` to justify body text